### PR TITLE
fix: Return created document in CreateDocument response

### DIFF
--- a/internal/document/handler.go
+++ b/internal/document/handler.go
@@ -141,7 +141,7 @@ func (h *HTTPHandler) createDocument(c *gin.Context) {
 	}
 
 	body.OwnerID = ownerID
-	documentID, err := h.documentService.CreateNewDocument(c.Request.Context(), body)
+	document, err := h.documentService.CreateNewDocument(c.Request.Context(), body)
 	if err != nil {
 		// Log the error for debugging purposes
 		c.Error(err)
@@ -151,9 +151,9 @@ func (h *HTTPHandler) createDocument(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusCreated, gin.H{
-		"document_id": documentID,
-	})
+	response := ToDocumentResponse(document)
+
+	c.JSON(http.StatusCreated, response)
 }
 
 func (h *HTTPHandler) getDocuments(c *gin.Context) {

--- a/internal/document/postgres.go
+++ b/internal/document/postgres.go
@@ -104,11 +104,11 @@ func (r *PostgresDocumentRepositoryImpl) UpdateDocument(ctx context.Context, doc
 }
 
 // CreateDocument implements DocumentRepository.
-func (r *PostgresDocumentRepositoryImpl) CreateDocument(ctx context.Context, document Document) (string, error) {
+func (r *PostgresDocumentRepositoryImpl) CreateDocument(ctx context.Context, document Document) (*Document, error) {
 	if err := gorm.G[Document](r.db).Create(ctx, &document); err != nil {
-		return "", fmt.Errorf("failed to create document: %w", err)
+		return nil, fmt.Errorf("failed to create document: %w", err)
 	}
-	return document.ID, nil
+	return &document, nil
 }
 
 // FindDocument implements DocumentRepository.

--- a/internal/document/repository.go
+++ b/internal/document/repository.go
@@ -11,7 +11,7 @@ type DocumentRepository interface {
 
 	DeleteDocument(ctx context.Context, documentID string) error
 	UpdateDocument(ctx context.Context, document Document) error
-	CreateDocument(ctx context.Context, document Document) (string, error)
+	CreateDocument(ctx context.Context, document Document) (*Document, error)
 	GetUserDocuments(ctx context.Context, userID string, userIsOwner bool) ([]Document, error)
 	FindDocument(ctx context.Context, userID, documentID string) *Document
 

--- a/internal/document/service.go
+++ b/internal/document/service.go
@@ -54,24 +54,24 @@ func (s *DocumentService) AddCollaboratorToDocument(ctx context.Context, data Ad
 	return nil
 }
 
-func (s *DocumentService) CreateNewDocument(ctx context.Context, data CreateDocumentDTO) (string, error) {
+func (s *DocumentService) CreateNewDocument(ctx context.Context, data CreateDocumentDTO) (*Document, error) {
 	var err error
-	docID, err := s.repo.CreateDocument(ctx, Document{
+	doc, err := s.repo.CreateDocument(ctx, Document{
 		Title:   data.Title,
 		OwnerID: data.OwnerID,
 		Content: nil,
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to create a new document: %w", err)
+		return nil, fmt.Errorf("failed to create a new document: %w", err)
 	}
 
 	s.repo.CreateDocumentPermission(ctx, DocumentPermission{
-		DocumentID: docID,
+		DocumentID: doc.ID,
 		UserID:     data.OwnerID,
 		Role:       RoleOwner,
 	})
 
-	return docID, nil
+	return doc, nil
 }
 
 func (s *DocumentService) GetUserDocuments(ctx context.Context, userID string, userIsOwner bool) ([]Document, error) {


### PR DESCRIPTION
## Summary
This PR updates the `CreateDocument` endpoint to return the complete created document object instead of just the document ID.

## Changes
- **Handler**: Modified `createDocument` handler to return a full `DocumentResponse` instead of just `document_id`
- **Service**: Updated `CreateNewDocument` to return `*Document` instead of `string` (document ID)
- **Repository**: Updated `CreateDocument` interface and implementation to return `*Document` instead of `string`

## Motivation
Returning the full document object provides the client with all necessary information about the newly created document (including timestamps, owner info, etc.) in a single request, improving the API's usability and reducing the need for additional requests.

## Testing
- Verified that the endpoint returns the complete document response with proper DTO conversion
- Ensured backward compatibility with existing permission creation logic